### PR TITLE
Update Popup handling in extensions (OSK-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to interact with popups and screens of different types with a single source vs. 
 It is important that any page, popup, or other screen wanting to be navigated to has been registered with the internal library
 using one of the `AddScreen` or `AddPopupHandler` methods in the `ServiceCollectionExtensions`. These extensions will require that
 consuming libraries have inherited `IScreen` or `IScreenPopup` respectively, when the methods are called.
-The library will throw errors in the event this is not the case.
+The library will throw errors in the event this is not the case. Most integrations will provide a base class to extend for popup related usage.
 
 # OSK.Maui.Screens.Blazor
 This adds an integration for screen and popup related management using blazor components that are used with Maui Blazor Hybrid applications.

--- a/src/OSK.Maui.Screens.Blazor/ServiceCollectionExtensions.cs
+++ b/src/OSK.Maui.Screens.Blazor/ServiceCollectionExtensions.cs
@@ -1,11 +1,17 @@
 ﻿using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Maui.Screens.Blazor.Internal.Services;
 using OSK.Maui.Screens.Blazor.Ports;
+using OSK.Maui.Screens.Ports;
 
 namespace OSK.Maui.Screens.Blazor
 {
     public static class ServiceCollectionExtensions
     {
+        /// <summary>
+        /// Adds blazor related screen handlers for navigation and popups
+        /// </summary>
+        /// <param name="services">The services to add to</param>
+        /// <returns>The services for chaining</returns>
         public static IServiceCollection AddBlazorScreens(this IServiceCollection services)
         {
             // The Maui root deppendency container doesn't consider navigations as a separate scope 
@@ -14,8 +20,23 @@ namespace OSK.Maui.Screens.Blazor
             // Blazor Screen Handler
             services.TryAddSingleton<IBlazorComponentProvider, BlazorComponentProvider>();
 
+            services.AddBlazorPopup<BlazorPopupComponent>();
             services.TryAddTransient<BlazorScreenHandler>();
             services.TryAddTransient<BlazorPopupComponentPage>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Provides a way to add blazor ppopups that deviate from the library standard <see cref="BlazorPopupComponent"/>
+        /// </summary>
+        /// <typeparam name="TPopup">The blazor popup component type</typeparam>
+        /// <param name="services">The services to add to</param>
+        /// <returns>The services for chaining</returns>
+        public static IServiceCollection AddBlazorPopup<TPopup>(this IServiceCollection services) 
+            where TPopup: BlazorPopupComponent, IScreenPopup
+        {
+            services.AddPopupProvider<TPopup, BlazorScreenHandler>();
 
             return services;
         }

--- a/src/OSK.Maui.Screens.CommunityToolkit/CommunityPopup.cs
+++ b/src/OSK.Maui.Screens.CommunityToolkit/CommunityPopup.cs
@@ -1,0 +1,10 @@
+﻿using CommunityToolkit.Maui.Views;
+using OSK.Maui.Screens.Ports;
+
+namespace OSK.Maui.Screens.CommunityToolkit
+{
+    public class CommunityPopup : Popup, IScreenPopup
+    {
+        public required IPopupHandler PopupHandler { set; protected get; }
+    }
+}

--- a/src/OSK.Maui.Screens.CommunityToolkit/MauiAppBuilderExtensions.cs
+++ b/src/OSK.Maui.Screens.CommunityToolkit/MauiAppBuilderExtensions.cs
@@ -7,15 +7,27 @@ namespace OSK.Maui.Screens.CommunityToolkit
 {
     public static class MauiAppBuilderExtensions
     {
+        /// <summary>
+        /// Adds community toolkit related screen popup handling
+        /// </summary>
+        /// <param name="builder">The maui app builder to add to</param>
+        /// <returns>The builder fo rchaining</returns>
         public static MauiAppBuilder AddCommunityScreens(this MauiAppBuilder builder)
         {
             builder.Services.TryAddTransient<CommunityToolkitPopupProvider>();
+            builder.AddCommunityPopup<CommunityPopup>();
 
             return builder;
         }
 
+        /// <summary>
+        /// Adds a custom community popup type that deviates from the standard <see cref="CommunityPopup"/>
+        /// </summary>
+        /// <typeparam name="TPopup">The community toolkit popup type</typeparam>
+        /// <param name="builder">The builder to add to</param>
+        /// <returns>The builder for chaining</returns>
         public static MauiAppBuilder AddCommunityPopup<TPopup>(this MauiAppBuilder builder)
-            where TPopup : Popup, IScreenPopup
+            where TPopup: Popup, IScreenPopup
         {
             builder.Services.AddPopupProvider<TPopup, CommunityToolkitPopupProvider>();
 

--- a/src/OSK.Maui.Screens.Mopups/MauiAppBuilderExtensions.cs
+++ b/src/OSK.Maui.Screens.Mopups/MauiAppBuilderExtensions.cs
@@ -7,13 +7,25 @@ namespace OSK.Maui.Screens.Mopups
 {
     public static class MauiAppBuilderExtensions
     {
+        /// <summary>
+        /// Add Mopup related screen popup handlers to the builder
+        /// </summary>
+        /// <param name="builder">The builder to add to</param>
+        /// <returns>The builder for chaining</returns>
         public static MauiAppBuilder AddMopupsScreens(this MauiAppBuilder builder)
         {
             builder.Services.TryAddTransient<MopupsPopupProvider>();
+            builder.AddMopupsPopup<MopupPopup>();
 
             return builder;
         }
 
+        /// <summary>
+        /// Adds mpopup related popup types that deviate from the standard <see cref="MopupPopup"/>
+        /// </summary>
+        /// <typeparam name="TPopup">The mopup popup type</typeparam>
+        /// <param name="builder">The builder to add to</param>
+        /// <returns>The builder for chaining</returns>
         public static MauiAppBuilder AddMopupsPopup<TPopup>(this MauiAppBuilder builder)
             where TPopup : PopupPage, IScreenPopup
         {

--- a/src/OSK.Maui.Screens.Mopups/MopupPopup.cs
+++ b/src/OSK.Maui.Screens.Mopups/MopupPopup.cs
@@ -1,0 +1,10 @@
+﻿using Mopups.Pages;
+using OSK.Maui.Screens.Ports;
+
+namespace OSK.Maui.Screens.Mopups
+{
+    public class MopupPopup : PopupPage, IScreenPopup
+    {
+        public required IPopupHandler PopupHandler { set; protected get; }
+    }
+}

--- a/src/OSK.Maui.Screens/MauiAppBuilderExtensions.cs
+++ b/src/OSK.Maui.Screens/MauiAppBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using OSK.Maui.Screens.Internal.Services;
-using OSK.Maui.Screens.Ports;
 
 namespace OSK.Maui.Screens
 {
@@ -18,14 +17,6 @@ namespace OSK.Maui.Screens
             builder.Services.AddScreen<TPage, PageScreenHandler>(route);
 
             return builder;
-        }
-
-        public static MauiAppBuilder AddPagePopup<TPage>(this MauiAppBuilder buiilder)
-            where TPage : Page, IScreenPopup
-        {
-            buiilder.Services.AddPopupProvider<TPage, PageScreenHandler>();
-
-            return buiilder;
         }
     }
 }

--- a/src/OSK.Maui.Screens/PagePopup.cs
+++ b/src/OSK.Maui.Screens/PagePopup.cs
@@ -1,0 +1,9 @@
+﻿using OSK.Maui.Screens.Ports;
+
+namespace OSK.Maui.Screens
+{
+    public abstract class PagePopup : Page, IScreenPopup
+    {
+        public required IPopupHandler PopupHandler { set; protected get; }
+    }
+}

--- a/src/OSK.Maui.Screens/ServiceCollectionExtensions.cs
+++ b/src/OSK.Maui.Screens/ServiceCollectionExtensions.cs
@@ -8,10 +8,17 @@ namespace OSK.Maui.Screens
     {
         #region Screen Services
 
+        /// <summary>
+        /// Adds the core screen navigation services that can handle the screen and popup navigation requests
+        /// </summary>
+        /// <param name="services">The services to add to</param>
+        /// <returns>The services for chaining</returns>
         public static IServiceCollection AddScreenNavigation(this IServiceCollection services)
         {
             services.AddTransient<IScreenService, ScreenService>();
             services.AddTransient<IScreenCommandFactory, ScreenCommandFactory>();
+            services.AddTransient<PageScreenHandler>();
+            services.AddPagePop<PagePopup>();
 
             return services;
         }
@@ -20,6 +27,28 @@ namespace OSK.Maui.Screens
 
         #region Integrations
 
+        /// <summary>
+        /// Adds a popup descriptor that is based on MAUI Pages
+        /// </summary>
+        /// <typeparam name="TPopup">A popup of a page type</typeparam>
+        /// <param name="services">The services to add to</param>
+        /// <returns>The services for chaining</returns>
+        public static IServiceCollection AddPagePop<TPopup>(this IServiceCollection services)
+            where TPopup : Page, IScreenPopup
+        {
+            services.AddPopupProvider<TPopup, PageScreenHandler>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a screen, registering it to the given route and associating it to the provided navigation handler
+        /// </summary>
+        /// <typeparam name="TScreen">The screen type</typeparam>
+        /// <typeparam name="TScreenNavigation">The navigation handler that is associated to screens of the provided type</typeparam>
+        /// <param name="services">THe services to add to</param>
+        /// <param name="route">The route the screen is assigned to</param>
+        /// <returns>The services for chaining</returns>
         public static IServiceCollection AddScreen<TScreen, TScreenNavigation>(this IServiceCollection services, string route)
             where TScreenNavigation : IScreenNavigationHandler
         {
@@ -28,6 +57,14 @@ namespace OSK.Maui.Screens
             return services;
         }
 
+        /// <summary>
+        /// Adds a screen, registering it to the given route and associating it to the provided navigation handler
+        /// </summary>
+        /// <param name="services">THe services to add to</param>
+        /// <param name="route">The route the screen is assigned to</param>
+        /// <param name="screenType">The type of screen that is displayed</param>
+        /// <param name="navigationHandlerType">The navigation handler that handles trnasitions to the screen</param>
+        /// <returns>The services for chaining</returns>
         public static IServiceCollection AddScreen(this IServiceCollection services, string route, Type screenType, 
             Type navigationHandlerType)
         {
@@ -35,6 +72,13 @@ namespace OSK.Maui.Screens
             return services.AddScreenDescriptor(new ScreenRouteDescriptor(route, navigationHandlerType, screenType));
         }
 
+        /// <summary>
+        /// Adds a given screen descriptor the dependency container
+        /// </summary>
+        /// <param name="services">The services to add to</param>
+        /// <param name="descriptor">A <see cref="ScreenRouteDescriptor"/> that describes all the required parts of a screen for appropriate navigation</param>
+        /// <returns>The services for chaining</returns>
+        /// <exception cref="InvalidOperationException">This is thrown when the descriptor is invalid (i.e. bad screen or navigation handler type)</exception>
         public static IServiceCollection AddScreenDescriptor(this IServiceCollection services, ScreenRouteDescriptor descriptor)
         {
             ArgumentNullException.ThrowIfNull(descriptor);
@@ -47,6 +91,13 @@ namespace OSK.Maui.Screens
             return services;
         }
 
+        /// <summary>
+        /// Adds a popup descriptor based on the provided types.
+        /// </summary>
+        /// <typeparam name="TPopupType">The popup object type</typeparam>
+        /// <typeparam name="TProviderType">The popup provider type</typeparam>
+        /// <param name="services">The services to add to</param>
+        /// <returns>The services for chaining</returns>
         public static IServiceCollection AddPopupProvider<TPopupType, TProviderType>(this IServiceCollection services)
             where TPopupType : IScreenPopup
             where TProviderType : IPopupProvider
@@ -54,6 +105,13 @@ namespace OSK.Maui.Screens
             return services.AddPopupProvider(new PopupDescriptor(typeof(TPopupType), typeof(TProviderType)));
         }
 
+        /// <summary>
+        /// Adds a popup descriptor to the dependency container
+        /// </summary>
+        /// <param name="services">The services to add to</param>
+        /// <param name="descriptor">The popup descriptor that describes all the required parts of a popup provider</param>
+        /// <returns>The services for chaining</returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public static IServiceCollection AddPopupProvider(this IServiceCollection services, PopupDescriptor descriptor)
         {
             ArgumentNullException.ThrowIfNull(descriptor);


### PR DESCRIPTION
Motivation
----
currently, the popup handlers provided by the library are only added after a separate call for adding specific popups is made. This is cumbersome and unnecessary since the main handlers can be added in the add screen extensions

Modifications
----
* Updated library to contain popup abstractions
* Added popup handlers that utilize the abstractions by default

Result
----
Library no longer needs special custom popup providers be added