### PR TITLE
Lessen Mopup Extension restriction (OSK-7)

### DIFF
--- a/src/OSK.Maui.Screens.Mopups/MauiAppBuilderExtensions.cs
+++ b/src/OSK.Maui.Screens.Mopups/MauiAppBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace OSK.Maui.Screens.Mopups
         /// <param name="builder">The builder to add to</param>
         /// <returns>The builder for chaining</returns>
         public static MauiAppBuilder AddMopupsPopup<TPopup>(this MauiAppBuilder builder)
-            where TPopup : PopupPage, IScreenPopup
+            where TPopup : IScreenPopup
         {
             builder.Services.AddPopupProvider<TPopup, MopupsPopupProvider>();
 


### PR DESCRIPTION
Motivation
----
The extension for the mopup provider requires users to use the specific abstraction by the library

Modifications
----
* Allow any mopup related popup to be used with the extension rather than the specific library implementation

Result
----
Mopup extension is a little more flexible

Fixes #7