### PR TITLE
Fix build warnings and adjust projects (OSK-13)

### DIFF
--- a/src/OSK.Maui.Screens.Blazor/Internal/Services/BlazorScreenHandler.cs
+++ b/src/OSK.Maui.Screens.Blazor/Internal/Services/BlazorScreenHandler.cs
@@ -16,7 +16,7 @@ internal class BlazorScreenHandler(IServiceProvider serviceProvider, IBlazorComp
     protected override async ValueTask<PopupHandler> GetPopupHandlerAsync(PopupNavigation popupNavigation,
         CancellationToken cancellationToken = default)
     {
-        var parentPage = popupNavigation.ParentPage ?? Application.Current?.MainPage;
+        var parentPage = popupNavigation.ParentPage ?? Application.Current?.Windows[0].Page;
         if (parentPage is null)
         {
             throw new ScreenPopupNavigationException("Unable to set Blazor component popup without a valid main or parent page.");
@@ -41,7 +41,7 @@ internal class BlazorScreenHandler(IServiceProvider serviceProvider, IBlazorComp
 
     protected override async Task<BlazorComponent> NavigateToScreenAsync(ScreenRouteDescriptor descriptor, CancellationToken cancellationToken)
     {
-        if (Application.Current?.MainPage is not ContentPage contentPage
+        if (Application.Current?.Windows[0].Page is not ContentPage contentPage
             || contentPage?.Content is not BlazorWebView)
         {
             throw new ScreenNavigationException("Unable to navigate to blazor component when main page is not set to a content page with a blazor web view.");

--- a/src/OSK.Maui.Screens.Blazor/OSK.Maui.Screens.Blazor.csproj
+++ b/src/OSK.Maui.Screens.Blazor/OSK.Maui.Screens.Blazor.csproj
@@ -5,7 +5,6 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/OSK.Maui.Screens.CommunityToolkit/Internal/Services/CommunityToolkitPopupProvider.cs
+++ b/src/OSK.Maui.Screens.CommunityToolkit/Internal/Services/CommunityToolkitPopupProvider.cs
@@ -10,7 +10,7 @@ internal class CommunityToolkitPopupProvider(IServiceProvider serviceProvider) :
     protected override ValueTask<PopupHandler> GetPopupHandlerAsync(PopupNavigation popupNavigation, CancellationToken cancellationToken)
     {
         var popup = (Popup)ServiceProvider.GetRequiredService(popupNavigation.PopupType);
-        var parentPage = popupNavigation.ParentPage ?? Shell.Current.Window.Page ?? Application.Current?.MainPage
+        var parentPage = popupNavigation.ParentPage ?? Shell.Current.Window.Page ?? Application.Current?.Windows[0].Page
             ?? throw new InvalidOperationException("Unable to show CommunityToolkit Popup without a valid parent page.");
 
         return new ValueTask<PopupHandler>(new CommunityToolkitPopupHandler(popup, parentPage));

--- a/src/OSK.Maui.Screens.CommunityToolkit/OSK.Maui.Screens.CommunityToolkit.csproj
+++ b/src/OSK.Maui.Screens.CommunityToolkit/OSK.Maui.Screens.CommunityToolkit.csproj
@@ -5,7 +5,6 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/OSK.Maui.Screens.Mopups/OSK.Maui.Screens.Mopups.csproj
+++ b/src/OSK.Maui.Screens.Mopups/OSK.Maui.Screens.Mopups.csproj
@@ -5,7 +5,6 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/OSK.Maui.Screens/Internal/Services/PageScreenHandler.cs
+++ b/src/OSK.Maui.Screens/Internal/Services/PageScreenHandler.cs
@@ -22,12 +22,12 @@ internal class PageScreenHandler(IServiceProvider serviceProvider) : ScreenHandl
             return new ValueTask<PopupHandler>(new PagePopupHandler(Shell.Current.Navigation, popup));
         }
 
-        if (Application.Current?.MainPage is null)
+        if (Application.Current?.Windows[0] is null)
         {
             throw new ScreenPopupNavigationException("Unable to create a popup without a current application set.");
         }
 
-        return new ValueTask<PopupHandler>(new PagePopupHandler(Application.Current.MainPage.Navigation, popup));
+        return new ValueTask<PopupHandler>(new PagePopupHandler(Application.Current.Windows[0].Navigation, popup));
     }
 
     protected override async Task<Page> NavigateToScreenAsync(ScreenRouteDescriptor descriptor, CancellationToken cancellationToken)
@@ -46,13 +46,13 @@ internal class PageScreenHandler(IServiceProvider serviceProvider) : ScreenHandl
             throw new ScreenNavigationException("Unable to navigate to a page without a current application set.");
         }
 
-        if (Application.Current.MainPage is NavigationPage navigationPage)
+        if (Application.Current.Windows[0].Page is NavigationPage navigationPage)
         {
             await navigationPage.PushAsync(screen);
         }
         else
         {
-            Application.Current.MainPage = screen;
+            Application.Current.Windows[0].Page = screen;
         }
 
         return screen;

--- a/src/OSK.Maui.Screens/OSK.Maui.Screens.csproj
+++ b/src/OSK.Maui.Screens/OSK.Maui.Screens.csproj
@@ -6,7 +6,6 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
Motivation
----
The project has a bunch of build warnings since updating to .NET10 and there are issues with package publishing

Modifications
----
* Adjusted project files to fix build warnings
* Adjust project files to allow package publishing

Result
----
Project has less warnings and should publish

Fixes #13