### PR TITLE
Add missing nuget information for Blazor.PopupPage Project (OSK-17)

### DIFF
--- a/src/OSK.Maui.Screens.Blazor.PopupPage/OSK.Maui.Screens.Blazor.PopupPage.csproj
+++ b/src/OSK.Maui.Screens.Blazor.PopupPage/OSK.Maui.Screens.Blazor.PopupPage.csproj
@@ -9,9 +9,17 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>true</IsPackable>
 
+		<Description>
+			Provides a default popup page implementation for blazor related popups and navigation with the screens library
+		</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Maui, Screen, Popup, Page, route, routing, navigation, nav, handler, provider, app, blazor, razor</PackageTags>
+		<Title>OSK.Maui.Screens.Blazor.PopupPage</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+
 	</PropertyGroup>
 
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>


### PR DESCRIPTION
Motivation
----
Released nuget package will be missing data if not specified in the project file.

Modifications
----
* add common mising data for nuget package in project file

Result
----
Project is ready for nuget publishing

Fixes #17